### PR TITLE
Add support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Ometria Sample/Pods
 Ometria.xcodeproj/xcuserdata
 Pods
 Ometria.xcworkspace
+Package.resolved
+.build
+.swiftpm

--- a/Ometria/Source/Swizzler.swift
+++ b/Ometria/Source/Swizzler.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Cata. All rights reserved.
 //
 
+import Foundation
+
 extension DispatchQueue {
     private static var _onceTracker = [String]()
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Ometria",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "Ometria",
+            targets: ["Ometria"]),
+    ],
+    dependencies: [
+        .package(name: "Firebase",
+                 url: "https://github.com/firebase/firebase-ios-sdk.git", from: "7.0.0")
+    ],
+    targets: [
+        .target(
+            name: "Ometria",
+            dependencies: [
+                .product(name: "FirebaseMessaging", package: "Firebase")
+            ],
+            path: "Ometria/Source"),
+    ]
+)


### PR DESCRIPTION
Adds support for Swift Package Manager. 

Worth noting that it can't be built using command-line `swift build` because the `Package.swift` file does not declare support for macOS. So matches the Podfile in that it is only supported for iOS projects.