### PR TITLE
Mark methods that use UIApplication as unavailable for non-app extensions

### DIFF
--- a/Sources/Ometria/ApplicationUtils.swift
+++ b/Sources/Ometria/ApplicationUtils.swift
@@ -21,7 +21,8 @@ extension Ometria {
         }
         return sharedApplication
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     static func doesAppUseScenes() -> Bool {
         let delegateClass: AnyClass! = object_getClass(UIApplication.shared.delegate)
         

--- a/Sources/Ometria/AutomaticLifecycleTracker.swift
+++ b/Sources/Ometria/AutomaticLifecycleTracker.swift
@@ -11,7 +11,8 @@ import UIKit
 open class AutomaticLifecycleTracker {
     
     var isRunning = false
-    
+
+    @available(iOSApplicationExtension, unavailable)
     func startTracking() {
         guard !isRunning else {
             return

--- a/Sources/Ometria/AutomaticPushTracker.swift
+++ b/Sources/Ometria/AutomaticPushTracker.swift
@@ -25,7 +25,8 @@ open class AutomaticPushTracker: NSObject {
     
     open var isRunning = false
     open var isDelegateObserverAdded = false
-    
+
+    @available(iOSApplicationExtension, unavailable)
     open func startTracking() {
         guard !isRunning else {
             return
@@ -39,7 +40,8 @@ open class AutomaticPushTracker: NSObject {
         
         NotificationCenter.default.addObserver(self, selector: #selector(firebaseTokenDidRefresh(notification:)), name: Notification.Name.MessagingRegistrationTokenRefreshed, object: nil)
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     open func stopTracking() {
         guard isRunning else {
             return
@@ -59,7 +61,8 @@ open class AutomaticPushTracker: NSObject {
             UNUserNotificationCenter.current().removeDelegateObserver(observer: self)
         }
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func swizzleDidRegisterForRemoteNotificationsWithDeviceToken() {
         Logger.verbose(message: "Swizzle did register for remote notifications")
         let newSelector = #selector(UIResponder.om_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
@@ -73,13 +76,15 @@ open class AutomaticPushTracker: NSObject {
                                     Logger.verbose(message: "Application did register for remote notifications")
         }
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func unswizzleDidRegisterForRemoteNotificationsWithDeviceToken() {
         let delegateClass: AnyClass! = object_getClass(UIApplication.shared.delegate)
         let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         Swizzler.unswizzleSelector(originalSelector, aClass: delegateClass)
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func swizzleDidFailToRegisterForRemoteNotificationsWithError() {
         Logger.verbose(message: "Swizzle did fail to register for remote notifications")
         let newSelector = #selector(UIResponder.om_application(_:didFailToRegisterForRemoteNotificationsWithError:))
@@ -93,14 +98,16 @@ open class AutomaticPushTracker: NSObject {
                                     Logger.verbose(message: "Application did fail to register for remote notifications")
         }
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func unswizzleDidFailToRegisterForRemoteNotificationsWithError() {
         let delegateClass: AnyClass! = object_getClass(UIApplication.shared.delegate)
         let originalSelector = #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:))
         
         Swizzler.unswizzleSelector(originalSelector, aClass: delegateClass)
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func swizzleDidReceiveSilentNotification() {
         Logger.verbose(message: "Swizzle application:didReceiveRemoteNotification:fetchCompletionHandler:")
         let newSelector = #selector(UIResponder.om_application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
@@ -114,7 +121,8 @@ open class AutomaticPushTracker: NSObject {
                                     Logger.debug(message: "Application didReceiveSilentNotification")
         }
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     private func unswizzleDidReceiveSilentNotification() {
         let delegateClass: AnyClass! = object_getClass(UIApplication.shared.delegate)
         let originalSelector = #selector(UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:))

--- a/Sources/Ometria/Ometria.swift
+++ b/Sources/Ometria/Ometria.swift
@@ -44,6 +44,7 @@ open class Ometria: NSObject, UNUserNotificationCenterDelegate {
      - Returns: returns an initialized Ometria instance object if needed to use or keep throughout the project. You can always get the initialized instance by calling sharedInstance()
      */
     @discardableResult
+    @available(iOSApplicationExtension, unavailable)
     open class func initialize(apiToken: String) -> Ometria {
         let ometria = Ometria(apiToken: apiToken, config: OmetriaConfig())
         instance = ometria
@@ -62,7 +63,8 @@ open class Ometria: NSObject, UNUserNotificationCenterDelegate {
         }
         return instance!
     }
-    
+
+    @available(iOSApplicationExtension, unavailable)
     init(apiToken: String, config: OmetriaConfig) {
         self.config = config
         self.apiToken = apiToken
@@ -481,7 +483,9 @@ open class Ometria: NSObject, UNUserNotificationCenterDelegate {
 }
 
 // MARK: - Deeplink Interaction
+@available(iOSApplicationExtension, unavailable)
 extension Ometria: OmetriaNotificationInteractionDelegate {
+
     public func handleDeepLinkInteraction(_ deepLink: URL) {
         Logger.debug(message: "Open URL: \(deepLink)", category: .push)
         if Ometria.sharedUIApplication()?.canOpenURL(deepLink) == true {


### PR DESCRIPTION
Ometria SDK doesn't build against Xcode 13 beta 4 due to this change highlighted in Xcode's release notes:

> Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

This is causing Ometria to fail to build with multiple instances of this error:
 
> 'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.

It is now a requirement if you know that the extension is only going to be used or is only appropriate for use by application targets to add the annotation below to any methods that use `UIApplication`:

```swift
@available(iOSApplicationExtension, unavailable)
```

This PR adds this annotation.