### PR TITLE
Remove fatalError to prevent crash

### DIFF
--- a/Ometria Sample/OmetriaSample/AppDelegate.swift
+++ b/Ometria Sample/OmetriaSample/AppDelegate.swift
@@ -24,12 +24,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         Ometria.initialize(apiToken: "YOUR_API_TOKEN_HERE", enableSwizzling: false, appGroupIdentifier: "APP_GROUP_IDENTIFIER")
         
         // Enable logs in order to see if there are any problems encountered
-        Ometria.sharedInstance().isLoggingEnabled = true
+        Ometria.sharedInstance()?.isLoggingEnabled = true
         
         // Set the notificationInteractionDelegate in order to provide actions for
         // notifications that contain a deeplink URL.
         // The default functionality when you don't assign a delegate is opening urls in a browser
-        Ometria.sharedInstance().notificationInteractionDelegate = self
+        Ometria.sharedInstance()?.notificationInteractionDelegate = self
         
         // Configure Firebase. Make sure you replace the GoogleService-Info.plist file
         // with the one from your project.
@@ -74,7 +74,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
-            Ometria.sharedInstance().handleFirebaseTokenChanged(token: fcmToken)
+            Ometria.sharedInstance()?.handleFirebaseTokenChanged(token: fcmToken)
         }
     }
     
@@ -83,13 +83,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        Ometria.sharedInstance().handleNotificationResponse(response)
+        Ometria.sharedInstance()?.handleNotificationResponse(response)
         print("Reaching Did receive notification response")
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         print("Reaching Will present notification")
-        Ometria.sharedInstance().handleReceivedNotification(notification)
+        Ometria.sharedInstance()?.handleReceivedNotification(notification)
         completionHandler([.alert, .sound])
     }
     
@@ -107,7 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if let urlString = notification.deepLinkActionUrl, let url = URL(string: urlString) {
             if UIApplication.shared.canOpenURL(url) == true {
                 UIApplication.shared.open(url)
-                Ometria.sharedInstance().trackDeepLinkOpenedEvent(link: urlString, screenName: "Safari")
+                Ometria.sharedInstance()?.trackDeepLinkOpenedEvent(link: urlString, screenName: "Safari")
             } else {
                 print("The provided deeplink URL (\(urlString) cannot be processed.")
             }
@@ -126,7 +126,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // get the final URL in your website by calling the following method.
             //
             // This is a straightforward implementation without any loading screens, but in the scenario where the users have slow data connectivity you might be waiting for a while until the redirect is obtained, so presenting a loading screen might be a good idea.
-            Ometria.sharedInstance().processUniversalLink(url) { (url, error) in
+            Ometria.sharedInstance()?.processUniversalLink(url) { (url, error) in
                 if let url = url {
                     let alert = UIAlertController(title: "Universal Link Processed", message: url.absoluteString, preferredStyle: .alert)
                     let okAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)

--- a/Ometria Sample/OmetriaSample/EventListViewController.swift
+++ b/Ometria Sample/OmetriaSample/EventListViewController.swift
@@ -50,46 +50,46 @@ class EventListViewController: UITableViewController {
         switch eventType {
         
         case .basketUpdated:
-            Ometria.sharedInstance().trackBasketUpdatedEvent(basket: createSampleBasket())
+            Ometria.sharedInstance()?.trackBasketUpdatedEvent(basket: createSampleBasket())
         
         case .basketViewed:
-            Ometria.sharedInstance().trackBasketViewedEvent()
+            Ometria.sharedInstance()?.trackBasketViewedEvent()
             
         case .checkoutStarted:
-            Ometria.sharedInstance().trackCheckoutStartedEvent(orderId: "sample_order_id")
+            Ometria.sharedInstance()?.trackCheckoutStartedEvent(orderId: "sample_order_id")
         
         case .orderCompleted:
-            Ometria.sharedInstance().trackOrderCompletedEvent(orderId: "sample_order_id", basket: createSampleBasket())
+            Ometria.sharedInstance()?.trackOrderCompletedEvent(orderId: "sample_order_id", basket: createSampleBasket())
         
         case .productListingViewed:
-            Ometria.sharedInstance().trackProductListingViewedEvent(listingType: "category", listingAttributes: ["categoryID": "sampleCategoryID"])
+            Ometria.sharedInstance()?.trackProductListingViewedEvent(listingType: "category", listingAttributes: ["categoryID": "sampleCategoryID"])
         
         case .productViewed:
-            Ometria.sharedInstance().trackProductViewedEvent(productId: "sample_product_id")
+            Ometria.sharedInstance()?.trackProductViewedEvent(productId: "sample_product_id")
         
         case .homeScreenViewed:
-            Ometria.sharedInstance().trackHomeScreenViewedEvent()
+            Ometria.sharedInstance()?.trackHomeScreenViewedEvent()
         
         case .screenViewedExplicit:
-            Ometria.sharedInstance().trackScreenViewedEvent(screenName: "sample_screen_name")
+            Ometria.sharedInstance()?.trackScreenViewedEvent(screenName: "sample_screen_name")
         
         case .profileIdentifiedByEmail:
-            Ometria.sharedInstance().trackProfileIdentifiedEvent(email: "sample@profile.com")
+            Ometria.sharedInstance()?.trackProfileIdentifiedEvent(email: "sample@profile.com")
             
         case .profileIdentifiedById:
-            Ometria.sharedInstance().trackProfileIdentifiedEvent(customerId: "sample_customer_id")
+            Ometria.sharedInstance()?.trackProfileIdentifiedEvent(customerId: "sample_customer_id")
         
         case .profileDeidentified:
-            Ometria.sharedInstance().trackProfileDeidentifiedEvent()
+            Ometria.sharedInstance()?.trackProfileDeidentifiedEvent()
         
         case .custom:
-            Ometria.sharedInstance().trackCustomEvent(customEventType: "custom_event", additionalInfo: ["sampleField": "sampleValue"])
+            Ometria.sharedInstance()?.trackCustomEvent(customEventType: "custom_event", additionalInfo: ["sampleField": "sampleValue"])
             
         case .flush:
-            Ometria.sharedInstance().flush()
+            Ometria.sharedInstance()?.flush()
             
         case .clear:
-            Ometria.sharedInstance().clear()
+            Ometria.sharedInstance()?.clear()
         }
     }
     

--- a/Ometria Sample/OmetriaSampleTests/OmetriaSampleTests.swift
+++ b/Ometria Sample/OmetriaSampleTests/OmetriaSampleTests.swift
@@ -122,7 +122,7 @@ final class OmetriaSampleTests: XCTestCase {
         }
         Ometria.initialize(apiToken: "token", eventCache: cache1, eventService: eventService1, enableSwizzling: false)
         for _ in 0..<100 {
-            Ometria.sharedInstance().trackProductViewedEvent(productId: UUID().uuidString)
+            Ometria.sharedInstance()?.trackProductViewedEvent(productId: UUID().uuidString)
         }
         Ometria.initialize(apiToken: "token", eventCache: cache2, eventService: eventService2, enableSwizzling: false)
         
@@ -141,7 +141,7 @@ final class OmetriaSampleTests: XCTestCase {
         let cache2 = EventCache(relativePathComponent: "2")
         Ometria.initialize(apiToken: "test", eventCache: cache1, eventService: eventService)
         for _ in 0..<100 {
-            Ometria.sharedInstance().trackProductViewedEvent(productId: UUID().uuidString)
+            Ometria.sharedInstance()?.trackProductViewedEvent(productId: UUID().uuidString)
         }
         Ometria.initialize(apiToken: "test2", eventCache: cache2, eventService: eventService)
         

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Firebase",
-                 url: "https://github.com/firebase/firebase-ios-sdk.git",
-                 "10.10.0"..<"11.0.0")
+                 url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,14 +12,9 @@ let package = Package(
             targets: ["Ometria"]),
     ],
     dependencies: [
-        .package(name: "Firebase",
-                 url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0")
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", .exact("11.7.0"))
     ],
     targets: [
-        .target(
-            name: "Ometria",
-            dependencies: [
-                .product(name: "FirebaseMessaging", package: "Firebase")
-                ]),
+        .target(name: "Ometria", dependencies: [.product(name: "FirebaseMessaging", package: "Firebase")]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Ometria"]),
     ],
     dependencies: [
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", .exact("11.7.0"))
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", .exact("11.15.0"))
     ],
     targets: [
         .target(name: "Ometria", dependencies: [.product(name: "FirebaseMessaging", package: "Firebase")]),

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Ometria logs any errors encountered during runtime by default.
 You can enable advanced logging if you want more information on what’s happening in the background. Just add the following line after initialising the library:
 
 ```swift
-Ometria.sharedInstance().isLoggingEnabled = true
+Ometria.sharedInstance()?.isLoggingEnabled = true
 ```
 
 ### Disabling Swizzling
@@ -147,7 +147,7 @@ Next, you will need to provide the Firebase push token every time Firebase updat
 ```swift
 func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
     if let token = fcmToken {
-        Ometria.sharedInstance().handleFirebaseTokenChanged(token: token)
+        Ometria.sharedInstance()?.handleFirebaseTokenChanged(token: token)
     }
 }
 ```
@@ -156,11 +156,11 @@ Finally the Ometria SDK needs to know when users receive and interact with push 
 
 ```swift
 func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    Ometria.sharedInstance().handleNotificationResponse(response)
+    Ometria.sharedInstance()?.handleNotificationResponse(response)
 }
 
 func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-    Ometria.sharedInstance().handleReceivedNotification(notification)
+    Ometria.sharedInstance()?.handleReceivedNotification(notification)
     completionHandler([.alert, .sound])
 }
 ```
@@ -199,7 +199,7 @@ let myItem = OmetriaBasketItem(
 let myItems = [myItem]
 let myBasket = OmetriaBasket(id: "basket-id", totalPrice: 12.0, currency: "USD", items: myItems, link: "http://sample.link.com")
 
-Ometria.sharedInstance().trackBasketUpdatedEvent(basket: myBasket)
+Ometria.sharedInstance()?.trackBasketUpdatedEvent(basket: myBasket)
 ```
 
 #### Profile identified
@@ -404,7 +404,7 @@ Instead, it composes batches of events that are sent to the backend during appli
 You can request the library to send all remaining events to the backend whenever you want by calling:
 
 ```swift
-Ometria.sharedInstance().flush()
+Ometria.sharedInstance()?.flush()
 ```
 
 ### Clear tracked events
@@ -414,7 +414,7 @@ You can completely clear all the events that have been tracked and not yet flush
 To do this, call the following method:
 
 ```swift
-Ometria.sharedInstance().clear()
+Ometria.sharedInstance()?.clear()
 ```
 
 ### Debugging events
@@ -525,7 +525,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Ometria.initialize(apiToken: "OMETRIA_API_TOKEN")
-        Ometria.sharedInstance().notificationInteractionDelegate = self
+        Ometria.sharedInstance()?.notificationInteractionDelegate = self
 
         return true
     }
@@ -552,7 +552,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let notificationContent = notification.request.content
-        let ometriaNotification = Ometria.sharedInstance().parseNotification(notificationContent)
+        let ometriaNotification = Ometria.sharedInstance()?.parseNotification(notificationContent)
         completionHandler([.alert, .sound])
     }
 }
@@ -621,7 +621,7 @@ However, Ometria emails contain obfuscated tracking URLs, and these need to be c
 func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     if let url = userActivity.webpageURL {
         // you can check here whether the URL is one that you can handle without converting it back
-        Ometria.sharedInstance().processUniversalLink(url) { (url, error) in
+        Ometria.sharedInstance()?.processUniversalLink(url) { (url, error) in
             if let url = url {
                 // you can now handle the retrieved url as you would any other url from your website
             } else {

--- a/Sources/Ometria/AutomaticLifecycleTracker.swift
+++ b/Sources/Ometria/AutomaticLifecycleTracker.swift
@@ -87,7 +87,7 @@ open class AutomaticLifecycleTracker {
       let fcmTokenLastRefreshDate: Date = OmetriaDefaults.fcmTokenLastRefreshDate ?? Date()
       guard let dateOneWeekAgo: Date = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: Date()) else { return }
       if fcmTokenLastRefreshDate < dateOneWeekAgo {
-        Ometria.sharedInstance().trackPushTokenRefreshedEvent(pushToken: fcmToken)
+        Ometria.sharedInstance()?.trackPushTokenRefreshedEvent(pushToken: fcmToken)
       }
     }
 }

--- a/Sources/Ometria/AutomaticLifecycleTracker.swift
+++ b/Sources/Ometria/AutomaticLifecycleTracker.swift
@@ -62,21 +62,21 @@ open class AutomaticLifecycleTracker {
     
     @objc func appDidEnterBackground() {
         Logger.verbose(message: "Application did enter background", category: .application)
-        Ometria.sharedInstance().trackAppBackgroundedEvent()
+        Ometria.sharedInstance()?.trackAppBackgroundedEvent()
     }
     
     @objc func appWillEnterForeground() {
         Logger.verbose(message: "Application will enter foreground", category: .application)
-        Ometria.sharedInstance().trackAppForegroundedEvent()
+        Ometria.sharedInstance()?.trackAppForegroundedEvent()
     }
     
     @objc func appWillResignActive() {
         Logger.verbose(message: "Application will resign active", category: .application)
-        Ometria.sharedInstance().trackAppBackgroundedEvent()
+        Ometria.sharedInstance()?.trackAppBackgroundedEvent()
     }
     
     @objc func appDidBecomeActive() {
         Logger.verbose(message: "Application did become active", category: .application)
-        Ometria.sharedInstance().trackAppForegroundedEvent()
+        Ometria.sharedInstance()?.trackAppForegroundedEvent()
     }
 }

--- a/Sources/Ometria/AutomaticPushTracker.swift
+++ b/Sources/Ometria/AutomaticPushTracker.swift
@@ -213,7 +213,7 @@ public class AutomaticPushTracker: NSObject {
     func processFirebaseToken(_ token: String) {
         OmetriaDefaults.fcmToken = token
         Logger.debug(message: "Application firebase token automatically captured:\n\(String(describing: token))")
-        Ometria.sharedInstance().trackPushTokenRefreshedEvent(pushToken: token)
+        Ometria.sharedInstance()?.trackPushTokenRefreshedEvent(pushToken: token)
     }
     
     // MARK: - Observer
@@ -250,7 +250,7 @@ extension UIResponder {
             }
         }
         
-        Ometria.sharedInstance().application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+        Ometria.sharedInstance()?.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
     }
     
     @objc func om_application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
@@ -274,7 +274,7 @@ extension UIResponder {
             }
         }
         
-        Ometria.sharedInstance().application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+        Ometria.sharedInstance()?.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
     }
     
     @objc func om_application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
@@ -298,7 +298,7 @@ extension UIResponder {
             }
         }
         
-        Ometria.sharedInstance().application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
+        Ometria.sharedInstance()?.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
     }
 }
 
@@ -321,7 +321,7 @@ extension NSObject {
             }
         }
         
-        Ometria.sharedInstance().userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        Ometria.sharedInstance()?.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
     }
     
     @objc func om_userNotificationCenter(_ center: UNUserNotificationCenter,
@@ -339,6 +339,6 @@ extension NSObject {
             }
         }
         
-        Ometria.sharedInstance().userNotificationCenter(center, willPresent: notification, withCompletionHandler: completionHandler)
+        Ometria.sharedInstance()?.userNotificationCenter(center, willPresent: notification, withCompletionHandler: completionHandler)
     }
 }

--- a/Sources/Ometria/NotificationHandler.swift
+++ b/Sources/Ometria/NotificationHandler.swift
@@ -41,14 +41,14 @@ class NotificationHandler {
     
     func handleReceivedNotification(_ userInfo: [AnyHashable : Any], withCompletionHandler completionHandler: ((UNNotificationPresentationOptions) -> Void)?) {
         if let notificationBody = parseNotificationContent(userInfo) {
-            Ometria.sharedInstance().trackNotificationReceivedEvent(context: notificationBody.context)
+            Ometria.sharedInstance()?.trackNotificationReceivedEvent(context: notificationBody.context)
         }
         completionHandler?([])
     }
     
     func handleNotificationResponse(_ userInfo: [AnyHashable : Any], withCompletionHandler completionHandler: (() -> Void)?) {
         if let notificationBody = parseNotificationContent(userInfo) {
-            Ometria.sharedInstance().trackNotificationInteractedEvent(context: notificationBody.context)
+            Ometria.sharedInstance()?.trackNotificationInteractedEvent(context: notificationBody.context)
             if let urlString = notificationBody.deepLinkActionURL {
                 if let url = URL(string: urlString) {
                     interactionDelegate?.handleDeepLinkInteraction(url)
@@ -88,7 +88,7 @@ class NotificationHandler {
             return ometriaNotification
         } catch let error as OmetriaError {
             Logger.error(message: error.localizedDescription)
-            Ometria.sharedInstance().trackErrorOccuredEvent(error: error)
+            Ometria.sharedInstance()?.trackErrorOccuredEvent(error: error)
             return nil
         } catch {
             Logger.error(message: error.localizedDescription)
@@ -111,7 +111,7 @@ class NotificationHandler {
             return notificationBody
         } catch let error as OmetriaError {
             Logger.error(message: error.localizedDescription)
-            Ometria.sharedInstance().trackErrorOccuredEvent(error: error)
+            Ometria.sharedInstance()?.trackErrorOccuredEvent(error: error)
             
             return nil
         } catch {
@@ -131,27 +131,27 @@ class NotificationHandler {
                 if lastKnownStatus != .authorized,
                    #available(iOS 12.0, *), lastKnownStatus != .provisional {
                     Logger.verbose(message: "Notification authorization status changed to 'authorized'.", category: .push)
-                    Ometria.sharedInstance().trackPermissionsUpdateEvent(hasPermissions: true)
+                    Ometria.sharedInstance()?.trackPermissionsUpdateEvent(hasPermissions: true)
                 }
                 
             case .denied:
                 if lastKnownStatus != .denied {
                     Logger.verbose(message: "Notification authorization status changed to 'denied'.", category: .push)
-                    Ometria.sharedInstance().trackPermissionsUpdateEvent(hasPermissions: false)
+                    Ometria.sharedInstance()?.trackPermissionsUpdateEvent(hasPermissions: false)
                 }
                 
             case .ephemeral:
                 if #available(iOS 14, *) {
                     if lastKnownStatus != .ephemeral {
                         Logger.verbose(message: "Notification authorization status changed to 'ephemeral'.", category: .push)
-                        Ometria.sharedInstance().trackPermissionsUpdateEvent(hasPermissions: true)
+                        Ometria.sharedInstance()?.trackPermissionsUpdateEvent(hasPermissions: true)
                     }
                 }
                 
             case .notDetermined:
                 if lastKnownStatus != .notDetermined {
                     Logger.verbose(message: "Notification authorization status changed to 'not determined'.", category: .push)
-                    Ometria.sharedInstance().trackPermissionsUpdateEvent(hasPermissions: false)
+                    Ometria.sharedInstance()?.trackPermissionsUpdateEvent(hasPermissions: false)
                 }
                 
             @unknown default:

--- a/Sources/Ometria/Ometria.swift
+++ b/Sources/Ometria/Ometria.swift
@@ -94,11 +94,8 @@ public class Ometria: NSObject, UNUserNotificationCenterDelegate {
      
      - Returns: returns the Ometria instance
      */
-    public class func sharedInstance() -> Ometria {
-        guard instance != nil else {
-            fatalError("You are not allowed to call the sharedInstance() method before calling initialize(apiToken:).")
-        }
-        return instance!
+    public class func sharedInstance() -> Ometria? {
+        return instance
     }
     
     @available(iOSApplicationExtension, unavailable)


### PR DESCRIPTION
This PR is a very quick and dirty hack to prevent an unnecessary crash in the SDK. Calling fatal in the `sharedInstance` is very aggressive and makes it very difficult to delay the initialisation of the SDK. I'm sure you can make this far more graceful, this is just to highlight the issue really.

