### PR TITLE
Release/1.8.0

### DIFF
--- a/Ometria Sample/OmetriaSample.xcodeproj/project.pbxproj
+++ b/Ometria Sample/OmetriaSample.xcodeproj/project.pbxproj
@@ -739,7 +739,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ometria.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -763,7 +763,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ometria.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Ometria.podspec
+++ b/Ometria.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'Ometria'
-  s.version             = '1.7.0'
+  s.version             = '1.8.0'
   s.module_name         = 'Ometria'
   s.license             = 'MIT'
   s.summary             = 'Ometria SDK for iOS (Swift)'

--- a/Sources/Ometria/AutomaticLifecycleTracker.swift
+++ b/Sources/Ometria/AutomaticLifecycleTracker.swift
@@ -63,7 +63,7 @@ open class AutomaticLifecycleTracker {
     @objc func appDidEnterBackground() {
         Logger.verbose(message: "Application did enter background", category: .application)
         Ometria.sharedInstance().trackAppBackgroundedEvent()
-      trackPushTokenRefreshedIfNecessary()
+        trackPushTokenRefreshedIfNecessary()
     }
     
     @objc func appWillEnterForeground() {
@@ -74,7 +74,7 @@ open class AutomaticLifecycleTracker {
     @objc func appWillResignActive() {
         Logger.verbose(message: "Application will resign active", category: .application)
         Ometria.sharedInstance().trackAppBackgroundedEvent()
-      trackPushTokenRefreshedIfNecessary()
+        trackPushTokenRefreshedIfNecessary()
     }
     
     @objc func appDidBecomeActive() {

--- a/Sources/Ometria/AutomaticLifecycleTracker.swift
+++ b/Sources/Ometria/AutomaticLifecycleTracker.swift
@@ -63,6 +63,7 @@ open class AutomaticLifecycleTracker {
     @objc func appDidEnterBackground() {
         Logger.verbose(message: "Application did enter background", category: .application)
         Ometria.sharedInstance().trackAppBackgroundedEvent()
+      trackPushTokenRefreshedIfNecessary()
     }
     
     @objc func appWillEnterForeground() {
@@ -73,10 +74,20 @@ open class AutomaticLifecycleTracker {
     @objc func appWillResignActive() {
         Logger.verbose(message: "Application will resign active", category: .application)
         Ometria.sharedInstance().trackAppBackgroundedEvent()
+      trackPushTokenRefreshedIfNecessary()
     }
     
     @objc func appDidBecomeActive() {
         Logger.verbose(message: "Application did become active", category: .application)
         Ometria.sharedInstance().trackAppForegroundedEvent()
+    }
+  
+    private func trackPushTokenRefreshedIfNecessary() {
+      guard let fcmToken = OmetriaDefaults.fcmToken else { return }
+      let fcmTokenLastRefreshDate: Date = OmetriaDefaults.fcmTokenLastRefreshDate ?? Date()
+      guard let dateOneWeekAgo: Date = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: Date()) else { return }
+      if fcmTokenLastRefreshDate < dateOneWeekAgo {
+        Ometria.sharedInstance().trackPushTokenRefreshedEvent(pushToken: fcmToken)
+      }
     }
 }

--- a/Sources/Ometria/Constants.swift
+++ b/Sources/Ometria/Constants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum Constants {
-    static let sdkVersion = "1.7.0"
+    static let sdkVersion = "1.8.0"
     public static let defaultTriggerLimit = 10
     static let flushMaxBatchSize = 100
     static let networkCallTimeoutSeconds: TimeInterval = 10

--- a/Sources/Ometria/Ometria.swift
+++ b/Sources/Ometria/Ometria.swift
@@ -511,6 +511,7 @@ public class Ometria: NSObject, UNUserNotificationCenterDelegate {
         notificationHandler.verifyPushNotificationAuthorizationStatus {[weak self] (hasAuthorization) in
             data[Constants.EventKeys.notifications] = hasAuthorization ? Constants.EventPredefinedValues.optIn : Constants.EventPredefinedValues.optOut
             self?.trackEvent(type: .pushTokenRefreshed, data: data)
+            OmetriaDefaults.fcmTokenLastRefreshDate = Date()
             self?.eventHandler.flushEvents()
         }
     }

--- a/Sources/Ometria/OmetriaDefaults.swift
+++ b/Sources/Ometria/OmetriaDefaults.swift
@@ -60,6 +60,8 @@ enum OmetriaDefaults {
     private static var __applePushToken: String?
     @UserDefault(key: "com.ometria.fcm_token", defaultValue: nil)
     private static var __fcmToken: String?
+    @UserDefault(key: "com.ometria.fcm_token_last_refresh_date", defaultValue: nil)
+    private static var __fcmTokenLastRefreshDate: Date?
     @UserDefault(key: "com.ometria.last_launch_date", defaultValue: nil)
     private static var __lastLaunchDate: Date?
     @UserDefault(key: "com.ometria.installment_id", defaultValue: nil)
@@ -88,6 +90,8 @@ enum OmetriaDefaults {
     static var applePushToken: String?
     @UserDefault(suite: appGroupIdentifier, key: "com.ometria.fcm_token", defaultValue: __fcmToken)
     static var fcmToken: String?
+    @UserDefault(suite: appGroupIdentifier, key: "com.ometria.fcm_token_last_refresh_date", defaultValue: __fcmTokenLastRefreshDate)
+    static var fcmTokenLastRefreshDate: Date?
     @UserDefault(suite: appGroupIdentifier, key: "com.ometria.last_launch_date", defaultValue: __lastLaunchDate)
     static var lastLaunchDate: Date?
     @UserDefault(suite: appGroupIdentifier, key: "com.ometria.installment_id", defaultValue: __installationID)


### PR DESCRIPTION
- fix processUniversalLink to only redirect the original link once, not recursively
- track push token refreshed event on background