### PR TITLE
Release version 1.8.3

### DIFF
--- a/Ometria.podspec
+++ b/Ometria.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'Ometria'
-  s.version             = '1.8.2'
+  s.version             = '1.8.3'
   s.module_name         = 'Ometria'
   s.license             = 'MIT'
   s.summary             = 'Ometria SDK for iOS (Swift)'

--- a/Ometria.xcodeproj/project.pbxproj
+++ b/Ometria.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		4EFF18B624EA55690020389A /* JSONCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18B524EA55690020389A /* JSONCache.swift */; };
 		4EFF18B824EA559A0020389A /* CodableCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18B724EA559A0020389A /* CodableCaching.swift */; };
 		4EFF18BB24EA63230020389A /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18BA24EA63230020389A /* EventHandler.swift */; };
+		7815691E2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */; };
 		EC56B60327048E23009D808A /* OmetriaNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC56B60227048E23009D808A /* OmetriaNotification.swift */; };
 /* End PBXBuildFile section */
 
@@ -81,6 +82,7 @@
 		4EFF18B524EA55690020389A /* JSONCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCache.swift; sourceTree = "<group>"; };
 		4EFF18B724EA559A0020389A /* CodableCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableCaching.swift; sourceTree = "<group>"; };
 		4EFF18BA24EA63230020389A /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
+		7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmetriaNotificationProcessor.swift; sourceTree = "<group>"; };
 		7F5D7686F934DEAE653B4617 /* Pods_Ometria.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Ometria.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC56B60227048E23009D808A /* OmetriaNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmetriaNotification.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -143,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				4E96AB4E24D4927900623FA6 /* NotificationHandler.swift */,
+				7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */,
 				4EF3711324F8468B00450B52 /* OmetriaNotificationServiceExtension.swift */,
 			);
 			name = "Notification Handling";
@@ -378,6 +381,7 @@
 				4EA10CED24ED73B9007FF49D /* OmetriaError.swift in Sources */,
 				4EC94EDC24B8B9ED00B8591C /* Ometria.swift in Sources */,
 				4EA10CE524ED5A97007FF49D /* JSONDecoder+KeyPath.swift in Sources */,
+				7815691E2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift in Sources */,
 				4E5B2E2A24ED4C320063FA50 /* Result.swift in Sources */,
 				4EF3710A24F39C4B00450B52 /* Array+Chunks.swift in Sources */,
 				4E96478524E3F90B00274FC3 /* OmetriaBasketItem.swift in Sources */,

--- a/Sources/Ometria/Constants.swift
+++ b/Sources/Ometria/Constants.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 public enum Constants {
-    static let sdkVersion = "1.8.2"
+    static let sdkVersion = "1.8.3"
     public static let defaultTriggerLimit = 10
+    public static let defaultFlushInterval = 60
     static let flushMaxBatchSize = 100
     static let networkCallTimeoutSeconds: TimeInterval = 10
     static let tooManyRequestsStatusCode: Int = 429
@@ -45,5 +46,4 @@ extension Constants {
         static let optIn = "opt-in"
         static let optOut = "opt-out"
     }
-    
 }

--- a/Sources/Ometria/OmetriaConfig.swift
+++ b/Sources/Ometria/OmetriaConfig.swift
@@ -9,14 +9,18 @@
 import Foundation
 
 class OmetriaConfig {
-    
     var flushLimit: Int
+    let flushInterval: Int
     var automaticallyTrackNotifications: Bool = true
     var automaticallyTrackAppLifecycle: Bool = true
     var isLoggingEnabled: Bool = false
     var logLevel: LogLevel = .warning
     
-    init(flushLimit: Int = Constants.defaultTriggerLimit) {
+    init(
+        flushLimit: Int = Constants.defaultTriggerLimit,
+        flushInterval: Int = Constants.defaultFlushInterval
+    ) {
         self.flushLimit = flushLimit
+        self.flushInterval = flushInterval
     }
 }

--- a/Sources/Ometria/OmetriaNotificationServiceExtension.swift
+++ b/Sources/Ometria/OmetriaNotificationServiceExtension.swift
@@ -6,84 +6,27 @@
 //  Copyright © 2020 Cata. All rights reserved.
 //
 
-import Foundation
 import UserNotifications
 
 open class OmetriaNotificationServiceExtension: UNNotificationServiceExtension {
-
-    var contentHandler: ((UNNotificationContent) -> Void)?
-    var bestAttemptContent: UNMutableNotificationContent?
-    
     /// override this function in subclass
     open func instantiateOmetria() -> Ometria? {
-        fatalError("This function needs to be overriden")
-    }
-
-    override open func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        let ometria = instantiateOmetria()
-        self.contentHandler = contentHandler
-        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-        
-        guard let notificationBody = NotificationHandler().parseNotificationContent(request.content.userInfo) else {
-            if let bestAttemptContent = bestAttemptContent {
-                contentHandler(bestAttemptContent)
-            }
-            return
-        }
-        
-        ometria?.trackNotificationReceivedEvent(context: notificationBody.context)
-        ometria?.flush()
-        
-        func failEarly() {
-            contentHandler(request.content)
-        }
-        
-        if let bestAttemptContent = bestAttemptContent {
-            
-            guard
-                let imageURLString = notificationBody.imageURL,
-                let imageURL = URL(string: imageURLString),
-                let data = NSData(contentsOf: imageURL) else
-            {
-                    failEarly()
-                    return
-            }
-            
-            guard let imageAttachment = create(imageFileIdentifier: imageURLString.components(separatedBy: "/").last!, data: data, options: nil) else {
-                failEarly()
-                return
-            }
-            
-            bestAttemptContent.attachments.append(imageAttachment)
-            contentHandler(bestAttemptContent)
-        }
-    }
-    
-    override open func serviceExtensionTimeWillExpire() {
-        // Called just before the extension will be terminated by the system.
-        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
-        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
-        }
-    }
-    
-    private func create(imageFileIdentifier: String, data: NSData, options: [NSObject : AnyObject]?) -> UNNotificationAttachment? {
-        let fileManager = FileManager.default
-        let tmpSubFolderName = ProcessInfo.processInfo.globallyUniqueString
-        let tmpSubFolderURL = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(tmpSubFolderName, isDirectory: true)
-
-        do {
-            try fileManager.createDirectory(at: tmpSubFolderURL!, withIntermediateDirectories: true, attributes: nil)
-            let fileURL = tmpSubFolderURL?.appendingPathComponent(imageFileIdentifier)
-            try data.write(to: fileURL!)
-            let imageAttachment = try UNNotificationAttachment.init(identifier: imageFileIdentifier, url: fileURL!, options: options)
-            
-            return imageAttachment
-        } catch let error {
-            print("error \(error)")
-        }
         return nil
     }
-    
-}
 
+    override open func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        guard let ometria = instantiateOmetria() else {
+            contentHandler(request.content)
+            return
+        }
+        OmetriaNotificationProcessor.handleNotification(
+            request,
+            using: ometria
+        ) { content in
+            contentHandler(request.content)
+        }
+    }
+}


### PR DESCRIPTION
- Added periodic event flushing with configurable interval (default: 60s)
- Implemented automatic flush timer that pauses when app enters background
- Added one-by-one event retry mechanism for batch failures
- Refactored notification service extension to use new OmetriaNotificationProcessor class
- Added rich push notification support with handleNotification method
- Improve sharedInstance() to return default instance instead of fatal error
- Update rate limiting logic for event flushing