### PR TITLE
Release version 1.8.3

### DIFF
--- a/Ometria.podspec
+++ b/Ometria.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'Ometria'
-  s.version             = '1.8.2'
+  s.version             = '1.8.3'
   s.module_name         = 'Ometria'
   s.license             = 'MIT'
   s.summary             = 'Ometria SDK for iOS (Swift)'

--- a/Ometria.xcodeproj/project.pbxproj
+++ b/Ometria.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		4EFF18B624EA55690020389A /* JSONCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18B524EA55690020389A /* JSONCache.swift */; };
 		4EFF18B824EA559A0020389A /* CodableCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18B724EA559A0020389A /* CodableCaching.swift */; };
 		4EFF18BB24EA63230020389A /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFF18BA24EA63230020389A /* EventHandler.swift */; };
+		7815691E2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */; };
 		EC56B60327048E23009D808A /* OmetriaNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC56B60227048E23009D808A /* OmetriaNotification.swift */; };
 /* End PBXBuildFile section */
 
@@ -81,6 +82,7 @@
 		4EFF18B524EA55690020389A /* JSONCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCache.swift; sourceTree = "<group>"; };
 		4EFF18B724EA559A0020389A /* CodableCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableCaching.swift; sourceTree = "<group>"; };
 		4EFF18BA24EA63230020389A /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
+		7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmetriaNotificationProcessor.swift; sourceTree = "<group>"; };
 		7F5D7686F934DEAE653B4617 /* Pods_Ometria.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Ometria.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC56B60227048E23009D808A /* OmetriaNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmetriaNotification.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -143,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				4E96AB4E24D4927900623FA6 /* NotificationHandler.swift */,
+				7815691D2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift */,
 				4EF3711324F8468B00450B52 /* OmetriaNotificationServiceExtension.swift */,
 			);
 			name = "Notification Handling";
@@ -378,6 +381,7 @@
 				4EA10CED24ED73B9007FF49D /* OmetriaError.swift in Sources */,
 				4EC94EDC24B8B9ED00B8591C /* Ometria.swift in Sources */,
 				4EA10CE524ED5A97007FF49D /* JSONDecoder+KeyPath.swift in Sources */,
+				7815691E2EBE05D500BD2DC0 /* OmetriaNotificationProcessor.swift in Sources */,
 				4E5B2E2A24ED4C320063FA50 /* Result.swift in Sources */,
 				4EF3710A24F39C4B00450B52 /* Array+Chunks.swift in Sources */,
 				4E96478524E3F90B00274FC3 /* OmetriaBasketItem.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -28,13 +28,34 @@ The easiest way to get Ometria into your iOS project is by using [CocoaPods](htt
 3. Create a Podfile in your Xcode project directory by running `pod init` in your terminal, edit the Podfile generated and add the following line: `pod 'Ometria'`.
 4. Run `pod install` in your Xcode project directory. CocoaPods should download and install the library, and create a new Xcode workspace. Open this workspace in Xcode or typing `open *.xcworkspace` in your terminal.
 
-4\. Add Notification Service Extension Target
+4\. Handling Push Notifications
 --------------------------
-In order to get the most out of Ometria, you are required to add a new target to your project.
 
-> :information_source: The Notification Service Extension has two purposes:
-> 1. Starting with iOS 12.0, Apple enabled regular applications to receive and display notifications that contain media content such as images. In order to be able to display the rich content, notifications have to be processed by the Notification Service Extension before being shown to the user.
-> 2. There are lots of users that forget to open their apps. In order for Ometria to accurately track all the notifications that were received, it needs to leverage the power of a background service, that has access to all notifications. 
+### **Option 1: Using `handleNotification` Method (Recommended)**
+
+Ometria provides a method that allows you to handle notifications directly in your app without creating a separate extension. This approach is simpler and works for most apps that want full push notification functionality.
+
+#### Usage:
+
+```swift
+func handleNotification(
+    _ request: UNNotificationRequest,
+    using ometria: Ometria,
+    contentHandler: @escaping (UNNotificationContent) -> Void
+)
+```
+
+**Explanation:**
+* This method gives you the same functionality as the Notification Service Extension:
+* Ometria can intercept the notification
+* Media content (images, videos) attached to notifications will be displayed correctly
+* No separate target or extension is needed
+* Ideal for apps that want to keep the setup simple while still supporting rich notifications
+
+
+### **Option 2: Using Notification Service Extension**
+
+For apps that require background processing of notifications (for example, when the user hasn’t opened the app), you can use a Notification Service Extension. This approach allows Ometria to accurately track all notifications received and display rich content.
 
 In order to add the extension, go to **File > New > Target**, and select **Notification Service Extension > Next**.
 
@@ -87,7 +108,10 @@ class NotificationService: OmetriaNotificationServiceExtension {
 }
 ```
 
-Now you can receive notifications from Ometria and you are also able to see the images that are attached to your notifications.
+**Result:**
+* Your app can now receive notifications from Ometria
+* Rich media content (images, videos) will be displayed in notifications
+* Notifications can be tracked even if the user hasn’t opened the app
 
 5\. Initialise the library
 --------------------------

--- a/Sources/Ometria/Constants.swift
+++ b/Sources/Ometria/Constants.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 public enum Constants {
-    static let sdkVersion = "1.8.2"
+    static let sdkVersion = "1.8.3"
     public static let defaultTriggerLimit = 10
+    public static let defaultFlushInterval = 60
     static let flushMaxBatchSize = 100
     static let networkCallTimeoutSeconds: TimeInterval = 10
     static let tooManyRequestsStatusCode: Int = 429
@@ -45,5 +46,4 @@ extension Constants {
         static let optIn = "opt-in"
         static let optOut = "opt-out"
     }
-    
 }

--- a/Sources/Ometria/Ometria.swift
+++ b/Sources/Ometria/Ometria.swift
@@ -776,7 +776,7 @@ extension Ometria {
 }
 
 //MARK: - Rich push notifications
-extension Ometria {
+public extension Ometria {
     /**
      Call this method from your `NotificationService.didReceive` function.
      It will automatically track the notification-received event and

--- a/Sources/Ometria/Ometria.swift
+++ b/Sources/Ometria/Ometria.swift
@@ -776,7 +776,7 @@ extension Ometria {
 }
 
 //MARK: - Rich push notifications
-public extension Ometria {
+extension Ometria {
     /**
      Call this method from your `NotificationService.didReceive` function.
      It will automatically track the notification-received event and

--- a/Sources/Ometria/OmetriaConfig.swift
+++ b/Sources/Ometria/OmetriaConfig.swift
@@ -9,14 +9,18 @@
 import Foundation
 
 class OmetriaConfig {
-    
     var flushLimit: Int
+    let flushInterval: Int
     var automaticallyTrackNotifications: Bool = true
     var automaticallyTrackAppLifecycle: Bool = true
     var isLoggingEnabled: Bool = false
     var logLevel: LogLevel = .warning
     
-    init(flushLimit: Int = Constants.defaultTriggerLimit) {
+    init(
+        flushLimit: Int = Constants.defaultTriggerLimit,
+        flushInterval: Int = Constants.defaultFlushInterval
+    ) {
         self.flushLimit = flushLimit
+        self.flushInterval = flushInterval
     }
 }

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -1,0 +1,149 @@
+import UserNotifications
+import Foundation
+
+/**
+ A helper class with static methods to process Ometria push notifications.
+ 
+ This class follows a composition pattern, allowing developers to call Ometria's
+ notification logic from within their own `UNNotificationServiceExtension`
+ without needing to subclass.
+ 
+ This approach ensures compatibility with other third-party SDKs
+ (like Firebase, etc.) that also need to process notifications.
+ */
+class OmetriaNotificationProcessor {
+    /**
+     The primary entry point for processing an Ometria notification.
+     
+     Call this method from your `NotificationService.didReceive` function.
+     It will automatically track the notification-received event and
+     process any rich push content (like images) before calling your `contentHandler`.
+     
+     - Parameter request: The original `UNNotificationRequest` received by the service extension.
+     - Parameter ometria: An initialized instance of the Ometria SDK.
+     - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
+     */
+    static func handleNotification(
+        _ request: UNNotificationRequest,
+        using ometria: Ometria,
+        contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        trackNotificationReceived(using: request.content.userInfo, ometria: ometria)
+        
+        let notificationContent = updatedNotificationContent(from: request)
+        contentHandler(notificationContent)
+    }
+}
+
+// MARK: - Private Helpers
+extension OmetriaNotificationProcessor {
+    /**
+     Tracks the notification received event.
+     
+     This method parses the notification payload and sends a tracking event to Ometria.
+     
+     - Parameter userInfo: The `userInfo` dictionary from the notification content.
+     - Parameter ometria: An initialized instance of the Ometria SDK.
+     */
+    private static func trackNotificationReceived(
+        using userInfo: [AnyHashable: Any],
+        ometria: Ometria
+    ) {
+        guard let notificationBody = NotificationHandler().parseNotificationContent(userInfo) else {
+            return
+        }
+        ometria.trackNotificationReceivedEvent(context: notificationBody.context)
+        ometria.flush()
+    }
+    
+    /**
+     Processes the notification for rich push content (e.g., images).
+     
+     If an Ometria image URL is found, this method will:
+     1. Download the image synchronously.
+     2. Save it to a temporary local file.
+     3. Create a `UNNotificationAttachment` from the file.
+     4. Add the attachment to a mutable copy of the notification content.
+     
+     - Parameter request: The original `UNNotificationRequest`.
+     - Returns: A `UNNotificationContent` object. This will be the
+                original, unmodified content if no image is processed,
+                or a `UNMutableNotificationContent` with the image
+                attachment if successful.
+     */
+    private static func updatedNotificationContent(
+        from request: UNNotificationRequest
+    ) -> UNNotificationContent {
+        guard let notificationBody = NotificationHandler().parseNotificationContent(request.content.userInfo)
+        else {
+            return request.content
+        }
+        
+        if let imageURLString = notificationBody.imageURL,
+           let imageURL = URL(string: imageURLString),
+           let data = try? Data(contentsOf: imageURL),
+           let bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+        {
+            if let imageAttachment = createAttachment(
+                imageFileIdentifier: imageURL.lastPathComponent,
+                data: data
+            ) {
+                bestAttemptContent.attachments.append(imageAttachment)
+            }
+            return bestAttemptContent
+        } else {
+            return request.content
+        }
+    }
+}
+
+// MARK: - Attachment Helper
+extension OmetriaNotificationProcessor {
+    /**
+     Creates a `UNNotificationAttachment` from image data.
+     
+     This helper writes the downloaded data to a temporary file in a
+     unique subdirectory, then creates a notification attachment
+     pointing to that file.
+     
+     - Parameter imageFileIdentifier: The desired file name for the image (e.g., "image.png").
+     - Parameter data: The raw `Data` of the image.
+     - Returns: A `UNNotificationAttachment` object, or `nil` if an error occurred.
+     */
+    private static func createAttachment(
+        imageFileIdentifier: String,
+        data: Data
+    ) -> UNNotificationAttachment? {
+        
+        let fileManager = FileManager.default
+        let tmpSubFolderName = ProcessInfo.processInfo.globallyUniqueString
+        guard let tmpSubFolderURL = NSURL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(tmpSubFolderName, isDirectory: true)
+        else {
+            return nil
+        }
+        
+        do {
+            try fileManager.createDirectory(
+                at: tmpSubFolderURL,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            
+            let fileURL = tmpSubFolderURL.appendingPathComponent(imageFileIdentifier)
+            try data.write(to: fileURL)
+            
+            let imageAttachment = try UNNotificationAttachment.init(
+                identifier: imageFileIdentifier,
+                url: fileURL,
+                options: nil
+            )
+            
+            return imageAttachment
+        } catch let error {
+            print("Ometria: Error creating notification attachment: \(error)")
+        }
+        
+        return nil
+    }
+}

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -11,7 +11,7 @@ import Foundation
  This approach ensures compatibility with other third-party SDKs
  (like Firebase, etc.) that also need to process notifications.
  */
-public final class OmetriaNotificationProcessor {
+internal final class OmetriaNotificationProcessor {
     /**
      The primary entry point for processing an Ometria notification.
      
@@ -23,7 +23,7 @@ public final class OmetriaNotificationProcessor {
      - Parameter ometria: An initialized instance of the Ometria SDK.
      - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
      */
-    public static func handleNotification(
+    internal static func handleNotification(
         _ request: UNNotificationRequest,
         using ometria: Ometria,
         contentHandler: @escaping (UNNotificationContent) -> Void

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -11,7 +11,7 @@ import Foundation
  This approach ensures compatibility with other third-party SDKs
  (like Firebase, etc.) that also need to process notifications.
  */
-final class OmetriaNotificationProcessor {
+public final class OmetriaNotificationProcessor {
     /**
      The primary entry point for processing an Ometria notification.
      
@@ -23,7 +23,7 @@ final class OmetriaNotificationProcessor {
      - Parameter ometria: An initialized instance of the Ometria SDK.
      - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
      */
-    static func handleNotification(
+    public static func handleNotification(
         _ request: UNNotificationRequest,
         using ometria: Ometria,
         contentHandler: @escaping (UNNotificationContent) -> Void

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -11,7 +11,7 @@ import Foundation
  This approach ensures compatibility with other third-party SDKs
  (like Firebase, etc.) that also need to process notifications.
  */
-public final class OmetriaNotificationProcessor {
+final class OmetriaNotificationProcessor {
     /**
      The primary entry point for processing an Ometria notification.
      
@@ -23,7 +23,7 @@ public final class OmetriaNotificationProcessor {
      - Parameter ometria: An initialized instance of the Ometria SDK.
      - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
      */
-    public static func handleNotification(
+    static func handleNotification(
         _ request: UNNotificationRequest,
         using ometria: Ometria,
         contentHandler: @escaping (UNNotificationContent) -> Void

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -11,7 +11,7 @@ import Foundation
  This approach ensures compatibility with other third-party SDKs
  (like Firebase, etc.) that also need to process notifications.
  */
-internal final class OmetriaNotificationProcessor {
+final class OmetriaNotificationProcessor {
     /**
      The primary entry point for processing an Ometria notification.
      
@@ -23,7 +23,7 @@ internal final class OmetriaNotificationProcessor {
      - Parameter ometria: An initialized instance of the Ometria SDK.
      - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
      */
-    internal static func handleNotification(
+    static func handleNotification(
         _ request: UNNotificationRequest,
         using ometria: Ometria,
         contentHandler: @escaping (UNNotificationContent) -> Void

--- a/Sources/Ometria/OmetriaNotificationProcessor.swift
+++ b/Sources/Ometria/OmetriaNotificationProcessor.swift
@@ -11,7 +11,7 @@ import Foundation
  This approach ensures compatibility with other third-party SDKs
  (like Firebase, etc.) that also need to process notifications.
  */
-class OmetriaNotificationProcessor {
+public final class OmetriaNotificationProcessor {
     /**
      The primary entry point for processing an Ometria notification.
      
@@ -23,7 +23,7 @@ class OmetriaNotificationProcessor {
      - Parameter ometria: An initialized instance of the Ometria SDK.
      - Parameter contentHandler: The `contentHandler` closure from the `didReceive` method.
      */
-    static func handleNotification(
+    public static func handleNotification(
         _ request: UNNotificationRequest,
         using ometria: Ometria,
         contentHandler: @escaping (UNNotificationContent) -> Void

--- a/Sources/Ometria/OmetriaNotificationServiceExtension.swift
+++ b/Sources/Ometria/OmetriaNotificationServiceExtension.swift
@@ -6,84 +6,27 @@
 //  Copyright © 2020 Cata. All rights reserved.
 //
 
-import Foundation
 import UserNotifications
 
 open class OmetriaNotificationServiceExtension: UNNotificationServiceExtension {
-
-    var contentHandler: ((UNNotificationContent) -> Void)?
-    var bestAttemptContent: UNMutableNotificationContent?
-    
     /// override this function in subclass
     open func instantiateOmetria() -> Ometria? {
-        fatalError("This function needs to be overriden")
-    }
-
-    override open func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        let ometria = instantiateOmetria()
-        self.contentHandler = contentHandler
-        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-        
-        guard let notificationBody = NotificationHandler().parseNotificationContent(request.content.userInfo) else {
-            if let bestAttemptContent = bestAttemptContent {
-                contentHandler(bestAttemptContent)
-            }
-            return
-        }
-        
-        ometria?.trackNotificationReceivedEvent(context: notificationBody.context)
-        ometria?.flush()
-        
-        func failEarly() {
-            contentHandler(request.content)
-        }
-        
-        if let bestAttemptContent = bestAttemptContent {
-            
-            guard
-                let imageURLString = notificationBody.imageURL,
-                let imageURL = URL(string: imageURLString),
-                let data = NSData(contentsOf: imageURL) else
-            {
-                    failEarly()
-                    return
-            }
-            
-            guard let imageAttachment = create(imageFileIdentifier: imageURLString.components(separatedBy: "/").last!, data: data, options: nil) else {
-                failEarly()
-                return
-            }
-            
-            bestAttemptContent.attachments.append(imageAttachment)
-            contentHandler(bestAttemptContent)
-        }
-    }
-    
-    override open func serviceExtensionTimeWillExpire() {
-        // Called just before the extension will be terminated by the system.
-        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
-        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
-        }
-    }
-    
-    private func create(imageFileIdentifier: String, data: NSData, options: [NSObject : AnyObject]?) -> UNNotificationAttachment? {
-        let fileManager = FileManager.default
-        let tmpSubFolderName = ProcessInfo.processInfo.globallyUniqueString
-        let tmpSubFolderURL = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(tmpSubFolderName, isDirectory: true)
-
-        do {
-            try fileManager.createDirectory(at: tmpSubFolderURL!, withIntermediateDirectories: true, attributes: nil)
-            let fileURL = tmpSubFolderURL?.appendingPathComponent(imageFileIdentifier)
-            try data.write(to: fileURL!)
-            let imageAttachment = try UNNotificationAttachment.init(identifier: imageFileIdentifier, url: fileURL!, options: options)
-            
-            return imageAttachment
-        } catch let error {
-            print("error \(error)")
-        }
         return nil
     }
-    
-}
 
+    override open func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        guard let ometria = instantiateOmetria() else {
+            contentHandler(request.content)
+            return
+        }
+        OmetriaNotificationProcessor.handleNotification(
+            request,
+            using: ometria
+        ) { content in
+            contentHandler(request.content)
+        }
+    }
+}


### PR DESCRIPTION
Added periodic event flushing with configurable interval (default: 60s)
Implemented automatic flush timer that pauses when app enters background
Added one-by-one event retry mechanism for batch failures
Refactored notification service extension to use new OmetriaNotificationProcessor class
Added rich push notification support with handleNotification method
Improve sharedInstance() to return default instance instead of fatal error
Update rate limiting logic for event flushing