### PR TITLE
Fix UIApplication compilation error when using SPM.

### DIFF
--- a/Sources/Ometria/EventHandler.swift
+++ b/Sources/Ometria/EventHandler.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import UIKit
 
 class EventHandler {
     private var eventService: EventServiceProtocol


### PR DESCRIPTION
When using Ometria with SPM, we see a compilation error due to the usage of `UIApplication.didEnterBackgroundNotification` in `EventHandler.swift`.
To fix it, we have to import `UIKit`.

Note that when using Cocoapods, everything seems to work fine, that's because Cocoapods is already including it in `Ometria.podspec`. See `s.frameworks = 'UIKit', 'Foundation'`

<img width="1624" height="1002" alt="Screenshot 2026-01-26 at 14 13 52" src="https://github.com/user-attachments/assets/a2f6bb95-cd2a-4778-a77b-c4cfacd842fe" />

