### PR TITLE
Add .ontology/ knowledge base

### DIFF
--- a/.ontology/INDEX.md
+++ b/.ontology/INDEX.md
@@ -1,0 +1,25 @@
+# ometria.ios_sdk
+
+**Language**: Swift (iOS)
+**Purpose**: Official Ometria iOS SDK. Distributed via CocoaPods and Swift Package Manager. Enables mobile apps to track customer behaviour events and handle push notifications.
+
+## Key capabilities
+- Customer behaviour event tracking
+- Push notification handling via `handleNotification` method (or Notification Extension)
+- CocoaPods: `pod 'Ometria'`
+- Swift Package Manager: `Package.swift`
+
+## Code structure
+- `Sources/` — SDK source code
+- `Ometria Sample/` — sample application
+- `Tests/` — test suite
+- `Ometria.xcodeproj/` — Xcode project
+
+## Distribution
+- CocoaPods: `Ometria`
+- Swift Package Manager
+
+## Related repos
+- `ometria.ios_sdk_internal` — internal/development notes
+- `ometria.android_sdk` — Android equivalent
+- `ometria.react_native_sdk` — React Native wrapper


### PR DESCRIPTION
Adds auto-generated \`.ontology/\` directory containing a structured knowledge base for this repository.

This enables Claude and other AI assistants to quickly understand the purpose, architecture, and key components of this repo without needing to crawl the full codebase each time.

🤖 Generated by the Ometria ontology crawler